### PR TITLE
Quick fixes for guild_cache and error logging to user

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ ModMail, but in Python
 
 - `token`: The bot's user token retrieved from Discord Developer Portal.
 - `application_id`: The bot's application ID retrieved from Discord Developer Portal.
-- `guild`: The guild ID.
-- `channel`: Modmail channel ID in specified guild (must be `TextChannel`).
+- `channel`: Modmail channel ID in guild (must be `TextChannel`).
 - `prefix`: The bot prefix (needed for slash command sync command).
 - `status`: The bot status.
 - `id_prefix`: The bot prefix for persistent views (e.g., `mm`)
@@ -18,7 +17,6 @@ ModMail, but in Python
 {
   "token": "abc123",
   "application_id": 1234567890,
-  "guild": 1234567890,
   "channel": 1234567890,
   "prefix": "]",
   "status": "DM to contact",
@@ -57,7 +55,6 @@ As aforementioned, you can also inject environment variables.
 docker container run --name modmail \
     -v database:/database \
     -e MODMAIL_TOKEN=foo \
-    -e MODMAIL_GUILD=123 \
     -e MODMAIL_CHANNEL=321 \
     -e MODMAIL_PREFIX=! \
     modmail-py

--- a/cogs/listeners.py
+++ b/cogs/listeners.py
@@ -35,7 +35,6 @@ class Listeners(commands.Cog):
         Args:
             message (discord.Message): The current message.
         """
-
         if message.guild is None and not message.author.bot:
             # Handle if user is not in guild
             if not (
@@ -60,6 +59,7 @@ class Listeners(commands.Cog):
         """
 
         user = message.author
+        guild = self.bot.get_guild(self.modmail_channel.guild.id)
 
         timeout = await db.get_timeout(user.id)
         current_time = int(datetime.datetime.now().timestamp())
@@ -102,7 +102,7 @@ class Listeners(commands.Cog):
         # `ticket` truthiness has been checked prior to the following lines
         await db.add_ticket_response(ticket.ticket_id, user.id, response, False)
 
-        embeds = await ticket_embed.channel_embed(self.modmail_channel.guild, ticket)
+        embeds = await ticket_embed.channel_embed(guild, ticket)
 
         message_embed, buttons_view = await ticket_embed.MessageButtonsView(
             self.bot, embeds

--- a/config.example.json
+++ b/config.example.json
@@ -1,7 +1,6 @@
 {
     "token": "",
     "application_id": 0,
-    "guild": 0,
     "channel": 0,
     "prefix": "",
     "status": "",

--- a/modmail.py
+++ b/modmail.py
@@ -19,7 +19,7 @@ intents = discord.Intents.default()
 intents.members = True
 intents.message_content = True
 
-member_cache = discord.MemberCacheFlags()
+member_cache = discord.MemberCacheFlags.all()
 
 modmail_config = Config()
 

--- a/modmail.py
+++ b/modmail.py
@@ -66,8 +66,11 @@ class Modmail(commands.Bot):
         logger.info(f"Bot '{bot.user.name}' is now connected.")
 
     async def on_command_error(self, ctx: commands.Context, exception) -> None:
+        if not isinstance(
+            exception, commands.CommandNotFound
+        ):  # Prevent sending CommandNotFound errors to the user
+            await ctx.send(exception)
         await super().on_command_error(ctx, exception)
-        await ctx.send(exception)
 
 
 bot = Modmail()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
 name = "modmail.py"
-version = "2.0.0"
+version = "2.0.1"
 readme = "README.md"
 description = "A Discord bot for managing modmail written in Python."

--- a/utils/config.py
+++ b/utils/config.py
@@ -8,7 +8,6 @@ _path = Path(__file__).parent / "../config.json"
 class Config(BaseConfig):
     token: SecretStr
     application_id: int
-    guild: int
     channel: int
     prefix: str
     status: str


### PR DESCRIPTION
- `await bot.fetch_channel` does not return complete guild properties (see documentation)
- The cached guild property can be used in the DM listener which hits the cache and does not make an extra API call
- Removed unused guild property from config and README
- Modified MemberCacheFlags to use method instead of class